### PR TITLE
Add Aristotle (Harmonic) inference backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,19 @@ Create `.env` with the API key for your chosen provider:
 ANTHROPIC_API_KEY=your-key-here   # for Claude models
 OPENAI_API_KEY=your-key-here      # for GPT models
 GEMINI_API_KEY=your-key-here      # for Gemini models
+ARISTOTLE_API_KEY=arstl_...       # for Harmonic's Aristotle (see note below)
 ```
+
+**Aristotle (Harmonic).** The `"Aristotle"` model routes to Harmonic's
+autonomous formal-reasoning agent instead of a chat LLM. It is an optional
+backend — install with `pip install -e ".[aristotle]"` (pulls in
+`aristotlelib`) and mint a key at
+<https://aristotle.harmonic.fun/dashboard/keys>. Because Aristotle runs its
+own internal tools and returns finished Lean files rather than per-turn tool
+calls, it carries integration caveats documented in
+[`core/inference/sdk/aristotle.py`](core/inference/sdk/aristotle.py): no
+per-turn tool calling, no in-flight steering (steer between turns via
+follow-up prompts), and no token-usage/caching accounting.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,11 @@ backend — install with `pip install -e ".[aristotle]"` (pulls in
 own internal tools and returns finished Lean files rather than per-turn tool
 calls, it carries integration caveats documented in
 [`core/inference/sdk/aristotle.py`](core/inference/sdk/aristotle.py): no
-per-turn tool calling, no in-flight steering (steer between turns via
-follow-up prompts), and no token-usage/caching accounting.
+per-turn tool calling and no token-usage/caching accounting. In-flight
+steering *is* supported — pass a `steer` (and/or `on_event`) callback to
+observe the live event stream and inject `project.ask(...)` to redirect a
+running task; between-turn steering via follow-up `complete()` calls works
+too.
 
 ## Quick Start
 

--- a/autoform/bot/aristotle_agent.py
+++ b/autoform/bot/aristotle_agent.py
@@ -30,13 +30,17 @@ workers is expensive; prefer ``min_agents_per_task: 1``.
 
 from __future__ import annotations
 
+import fcntl
 import logging
 import shutil
 import subprocess
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from core import worktree
+from core.coordination.pool import AgentPool
 from core.inference.sdk.aristotle import AristotleInference, EventObserver, SteerCallback
 
 logger = logging.getLogger(__name__)
@@ -148,6 +152,20 @@ class AristotleAgent:
         return self._messages
 
     # ------------------------------------------------------------------
+    # Pool lifecycle (AgentPool.initialize/__aenter__ + shutdown/close).
+    # Aristotle needs no warm-up (no REPL/LSP/subprocesses), so these no-op.
+    # ------------------------------------------------------------------
+
+    async def __aenter__(self) -> AristotleAgent:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    async def close(self) -> None:
+        return None
+
+    # ------------------------------------------------------------------
     # Landing Aristotle's output into the worktree
     # ------------------------------------------------------------------
 
@@ -228,3 +246,61 @@ def create_aristotle_agents(
         )
         for i, wt in enumerate(worktrees)
     ]
+
+
+def create_aristotle_pool(
+    repo_root: Path,
+    num_agents: int,
+    *,
+    agent_id_prefix: str = "aristotle",
+    run_id: str | None = None,
+    system_prompt: str = DEFAULT_WORKER_SYSTEM_PROMPT,
+    poll_interval: int = 20,
+    max_wait_seconds: float | None = 5400,
+    on_event: EventObserver | None = None,
+    steer: SteerCallback | None = None,
+) -> AgentPool:
+    """Create an ``AgentPool`` of Aristotle workers — the Mode-B analog of
+    ``create_lean_pool``.
+
+    Mirrors the LLM pool's worktree setup (NFS-safe lock + ``git worktree``
+    + a ``.lake/packages`` symlink so ``lake build`` works in the worktree),
+    but builds ``AristotleAgent``s and no reviewers (the build gate and the
+    supervisor's eval harness still hold Aristotle's output to the same bar;
+    a reviewer can later be added, or the ``steer`` hook can play that role
+    in-flight).
+    """
+    if run_id is None:
+        run_id = "run-" + datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    run_worktrees_dir = repo_root.parent / "worktrees" / run_id
+    run_worktrees_dir.mkdir(parents=True, exist_ok=True)
+
+    wt_paths: list[Path] = []
+    lock_path = repo_root / ".worktree_lock"
+    with open(lock_path, "w") as lock_file:
+        logger.info("[%s] Waiting for worktree lock...", agent_id_prefix)
+        fcntl.lockf(lock_file, fcntl.LOCK_EX)
+        subprocess.run(["git", "-C", str(repo_root), "worktree", "prune"], capture_output=True)
+        for i in range(num_agents):
+            wt_name = f"{run_id}-{agent_id_prefix}-worker-{i}"
+            wt_paths.append(worktree.create_worktree(repo_root, wt_name, worktrees_dir=run_worktrees_dir))
+        logger.info("[%s] Created %d Aristotle worktrees", agent_id_prefix, num_agents)
+
+    # Share pre-resolved Mathlib deps so `lake build` in the worktree is cheap.
+    for wt in wt_paths:
+        lake_src = repo_root / ".lake" / "packages"
+        lake_dst = Path(wt) / ".lake" / "packages"
+        if lake_src.exists() and not lake_dst.exists():
+            lake_dst.parent.mkdir(parents=True, exist_ok=True)
+            lake_dst.symlink_to(lake_src.resolve())
+
+    agents = create_aristotle_agents(
+        worktrees=[Path(w) for w in wt_paths],
+        id_prefix=f"{agent_id_prefix}-worker",
+        system_prompt=system_prompt,
+        poll_interval=poll_interval,
+        max_wait_seconds=max_wait_seconds,
+        on_event=on_event,
+        steer=steer,
+    )
+    return AgentPool(agents=agents, reviewers={})

--- a/autoform/bot/aristotle_agent.py
+++ b/autoform/bot/aristotle_agent.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import fcntl
 import logging
+import re
 import shutil
 import subprocess
 import tempfile
@@ -44,6 +45,10 @@ from core.coordination.pool import AgentPool
 from core.inference.sdk.aristotle import AristotleInference, EventObserver, SteerCallback
 
 logger = logging.getLogger(__name__)
+
+_STANDARD_AXIOMS = {"propext", "Classical.choice", "Quot.sound"}
+_DECL_RE = re.compile(r"^(?:noncomputable )?(?:theorem|lemma|def|instance)\s+([A-Za-z_][\w'.]*)", re.M)
+_AXIOM_RE = re.compile(r"(?:^|[^A-Za-z])axiom\s")
 
 # Credit Aristotle as the author of the Lean it writes (committer stays the
 # pipeline identity so git history is well-formed).
@@ -243,6 +248,276 @@ def create_aristotle_agents(
         )
         for i, wt in enumerate(worktrees)
     ]
+
+
+REVIEWER_SYSTEM_PROMPT = (
+    "You are a STRICT, ADVERSARIAL reviewer of Lean 4 / Mathlib formalizations produced "
+    "by an autonomous prover. Your default verdict is REJECTED; APPROVE only if, after "
+    "actively hunting for defects, you find none. You are given MECHANICAL GROUND TRUTH "
+    "(a full-file scan and `#print axioms` results) — trust it over any prose or "
+    "docstring. REJECT if ANY of the following holds:\n"
+    "1. **Hidden gaps / axioms** — the scan shows `sorry`/`admit`/raw `axiom`/`native_decide`, "
+    "OR `#print axioms` lists `sorryAx` or any axiom outside {propext, Classical.choice, "
+    "Quot.sound}.\n"
+    "2. **Vacuity / triviality** — a theorem restates `True`/something trivially provable; an "
+    "`instance` is vacuous; a proof closes a goal via `False.elim` of a false hypothesis.\n"
+    "3. **Forced generality** — a parameter advertised as general is secretly pinned (e.g. a "
+    "smoothness `k` constrained to `⊤`, or `k = c`), making the 'general' result trivial.\n"
+    "4. **Weakened statement** — extra hypotheses not warranted, or content hidden in "
+    "structure/class fields (a Theorem/Proposition must be a proved theorem, not an assumed "
+    "field). The claimed result must actually be established (e.g. an `IsManifold` instance "
+    "must really prove `ContDiffOn` of the transitions, not merely assert a ChartedSpace).\n"
+    "5. **Task not met** — the change does not actually accomplish the stated task.\n"
+    "When uncertain, REJECT. Begin your reply with exactly `APPROVED` or `REJECTED`, then give "
+    "specific reasons grounded in the mechanical evidence and the code."
+)
+
+
+def _line_has_nonstandard_axiom(line: str) -> bool:
+    """True if a `#print axioms` line mentions `sorryAx` or any axiom outside the
+    standard set."""
+    if "sorryAx" in line:
+        return True
+    tail = line.split("axioms:", 1)[-1]
+    names = re.findall(r"[A-Za-z_][\w.]*", tail)
+    return any(nm not in _STANDARD_AXIOMS for nm in names)
+
+
+def _axiom_audit(worktree: Path, file_to_decls: dict[Path, list[str]]) -> str:
+    """`#print axioms` on each changed file's top-level declarations — the
+    un-foolable check for hidden `sorryAx` / non-standard axioms.
+
+    Appends `#print axioms` lines to a copy of each file and elaborates it
+    (reliable: the copy is self-contained, so no cross-module import resolution
+    is needed). Flags any non-standard axiom. Best-effort per file.
+    """
+    out_lines: list[str] = []
+    any_bad = False
+    for f, decls in file_to_decls.items():
+        if not decls:
+            continue
+        tmp = f.parent / f"_AxiomAudit_{f.stem}.lean"
+        try:
+            tmp.write_text(f.read_text() + "\n\n" + "".join(f"#print axioms {d}\n" for d in decls))
+            proc = subprocess.run(
+                ["lake", "env", "lean", str(tmp.relative_to(worktree))],
+                cwd=str(worktree), capture_output=True, text=True, timeout=900,
+            )
+        except Exception as err:  # pragma: no cover
+            out_lines.append(f"- {f.name}: axiom audit could not run: {err}")
+            continue
+        finally:
+            tmp.unlink(missing_ok=True)
+        ax = [ln.strip() for ln in (proc.stdout + proc.stderr).splitlines() if "depends on axioms" in ln]
+        for ln in ax:
+            if _line_has_nonstandard_axiom(ln):
+                any_bad = True
+                out_lines.append("  ⚠️ " + ln)
+            else:
+                out_lines.append("  " + ln)
+        if not ax:
+            out_lines.append(f"- {f.name}: (no axiom output — elaboration may have failed)")
+    header = "⚠️ NON-STANDARD AXIOM / sorryAx DETECTED" if any_bad else "OK: only standard axioms"
+    return header + "\n" + ("\n".join(out_lines) or "(nothing to audit)")
+
+
+def _mechanical_audit(worktree: Path) -> tuple[str, list[Path]]:
+    """Full-file scan of the changed `.lean` files + `#print axioms`. Returns the
+    report text and the list of changed Lean files."""
+    names = subprocess.run(
+        ["git", "diff", "--name-only", "HEAD~1"], cwd=str(worktree),
+        capture_output=True, text=True,
+    ).stdout.split()
+    lean_files = [worktree / n for n in names if n.endswith(".lean")]
+    scan_lines, file_to_decls = [], {}
+    for f in lean_files:
+        txt = f.read_text() if f.exists() else ""
+        rel = f.relative_to(worktree)
+        scan_lines.append(
+            f"- {rel}: sorry={txt.count('sorry')} admit={txt.count('admit')} "
+            f"axiom={len(_AXIOM_RE.findall(txt))} native_decide={txt.count('native_decide')}"
+        )
+        file_to_decls[f] = _DECL_RE.findall(txt)
+    report = (
+        "## Mechanical full-file scan (ground truth)\n" + "\n".join(scan_lines)
+        + "\n\n## #print axioms (ground truth)\n" + _axiom_audit(worktree, file_to_decls)
+    )
+    return report, lean_files
+
+
+class ClaudeReviewer:
+    """A Claude-backed reviewer that duck-types the reviewer surface
+    ``ConcurrentAgents.review`` uses (``id``, async ``call``, ``reset``,
+    ``set_trace``, ``total_turns``, ``messages``).
+
+    Unlike the full tool-calling reviewer agent, it has no tools: it computes
+    the worktree diff itself and asks Claude for an ``APPROVED``/``REJECTED``
+    verdict. The verdict gates the merge exactly like the pipeline's reviewer.
+    """
+
+    def __init__(
+        self, *, id: str, worktree_path: Path | str, model: str = "Opus 4.6",
+        use_cli: bool = False, rigorous: bool = True,
+    ) -> None:
+        self.id = id
+        self.worktree_path = Path(worktree_path)
+        self._model = model
+        self._use_cli = use_cli  # route via the `claude` CLI (Max OAuth) instead of the SDK
+        self._rigorous = rigorous  # run mechanical ground-truth checks (scan + #print axioms)
+        self.total_turns = 0
+        self._messages: list[dict[str, Any]] = []
+
+    async def call(self, user_message: str | None = None) -> str:
+        import asyncio
+
+        self.total_turns += 1
+        diff = subprocess.run(
+            ["git", "diff", "HEAD~1"], cwd=str(self.worktree_path),
+            capture_output=True, text=True,
+        ).stdout
+        if self._rigorous:
+            # Un-foolable ground truth: full-file scan + `#print axioms`, plus the
+            # whole changed files (not just the diff) so nothing escapes review.
+            audit, lean_files = await asyncio.to_thread(_mechanical_audit, self.worktree_path)
+            full = []
+            for f in lean_files:
+                try:
+                    full.append(f"### {f.name} (full)\n```lean\n{f.read_text()[:30000]}\n```")
+                except OSError:
+                    pass
+            context = audit + "\n\n" + "\n\n".join(full) + f"\n\n## Diff\n```diff\n{diff[:20000]}\n```"
+        else:
+            context = f"## Changed code (git diff HEAD~1)\n```diff\n{diff[:40000]}\n```"
+        prompt = (
+            f"{user_message or ''}\n\n{context}\n\n"
+            "Reply APPROVED or REJECTED (first word), then specific reasons grounded in the evidence."
+        )
+        self._messages = [{"role": "user", "content": prompt}]
+        if self._use_cli:
+            # Scrub ANTHROPIC_API_KEY so the CLI uses Max OAuth (not API billing).
+            import os
+
+            env = os.environ.copy()
+            env.pop("ANTHROPIC_API_KEY", None)
+            proc = await asyncio.to_thread(
+                subprocess.run,
+                ["claude", "-p", REVIEWER_SYSTEM_PROMPT + "\n\n" + prompt, "--output-format", "text"],
+                capture_output=True, text=True, env=env,
+            )
+            answer = (proc.stdout or "").strip() or "REJECTED: reviewer produced no output"
+        else:
+            from core.inference.client import create_inference, lookup_model
+
+            inf = create_inference(lookup_model(self._model))
+            inf.set_system_prompt(REVIEWER_SYSTEM_PROMPT)
+            inf.add_user_message(prompt)
+            result = await inf.complete()
+            answer = (result.text or "").strip()
+        self._messages.append({"role": "assistant", "content": answer})
+        return answer
+
+    def reset(self) -> None:
+        self.total_turns = 0
+        self._messages = []
+
+    def set_trace(self, trace: Any | None) -> None:
+        return None
+
+    @property
+    def messages(self) -> list[dict[str, Any]]:
+        return self._messages
+
+    async def __aenter__(self) -> ClaudeReviewer:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+    async def close(self) -> None:
+        return None
+
+
+def _claude_cli(prompt: str, *, timeout: int = 180) -> str:
+    """Invoke the `claude` CLI (Max OAuth — `ANTHROPIC_API_KEY` scrubbed). Returns
+    stdout, or "" on failure."""
+    import os
+
+    env = os.environ.copy()
+    env.pop("ANTHROPIC_API_KEY", None)
+    try:
+        proc = subprocess.run(
+            ["claude", "-p", prompt, "--output-format", "text"],
+            capture_output=True, text=True, env=env, timeout=timeout,
+        )
+        return (proc.stdout or "").strip()
+    except Exception as err:  # pragma: no cover
+        logger.warning("claude CLI failed: %s", err)
+        return ""
+
+
+STEER_JUDGE_RUBRIC = (
+    "You are the live-steering judge ('Hermes') for an autonomous Lean prover. You see a "
+    "window of its recent events (thinking, file edits, errors). Decide whether it is going "
+    "OFF-COURSE relative to the GOAL — e.g. abandoning the goal, axiomatizing/`sorry`-ing what "
+    "it was asked to prove, weakening or pinning a parameter it was told to keep general, "
+    "going in circles, or building the wrong thing. Only steer when genuinely warranted; a "
+    "needless steer wastes a turn. If steering, give a SHORT, concrete corrective instruction."
+)
+
+
+def make_claude_steer(goal: str, *, min_gap_s: float = 120.0, max_steers: int = 3):
+    """Build a `steer` callback (for AristotleInference) backed by a Claude judge.
+
+    On each batch of new events it (rate-limited) asks Claude whether the prover
+    is off-course w.r.t. ``goal``; if so, returns a corrective prompt that the
+    backend injects via ``project.ask`` mid-run. This is the working replacement
+    for the keyword heuristic (which never fired): it reads the actual reasoning
+    in the event stream rather than grepping for tokens.
+    """
+    import json
+    import time
+
+    state = {"last": 0.0, "count": 0, "reasons": []}
+
+    async def steer(new_events: list[Any], task: Any) -> str | None:
+        import asyncio
+
+        if state["count"] >= max_steers:
+            return None
+        relevant = [
+            e for e in new_events
+            if getattr(getattr(e, "event_type", None), "name", "") in ("EDITING_FILE", "THINKING", "MESSAGE", "ERROR")
+        ]
+        if not relevant:
+            return None
+        now = time.monotonic()
+        if now - state["last"] < min_gap_s:
+            return None
+        window = "\n".join(
+            f"[{getattr(e.event_type, 'name', '?')}] {(getattr(e, 'content', None) or '')[:300]}"
+            for e in relevant[-8:]
+        )
+        prompt = (
+            f"{STEER_JUDGE_RUBRIC}\n\n## GOAL\n{goal}\n\n## RECENT EVENTS\n{window}\n\n"
+            f"## PRIOR STEER REASONS\n{state['reasons'] or '(none)'}\n\n"
+            'Return ONE LINE of JSON: {"steer": <bool>, "reason": "<short>", "prompt": "<corrective instruction or empty>"}'
+        )
+        raw = await asyncio.to_thread(_claude_cli, prompt)
+        if not raw or "{" not in raw:
+            return None
+        try:
+            decision = json.loads(raw[raw.index("{"): raw.rindex("}") + 1])
+        except Exception:
+            return None
+        if decision.get("steer") and (decision.get("prompt") or "").strip():
+            state["last"] = now
+            state["count"] += 1
+            state["reasons"].append((decision.get("reason") or "")[:120])
+            logger.info("Claude steer #%d: %s", state["count"], state["reasons"][-1])
+            return decision["prompt"].strip()
+        return None
+
+    return steer
 
 
 def create_aristotle_pool(

--- a/autoform/bot/aristotle_agent.py
+++ b/autoform/bot/aristotle_agent.py
@@ -116,11 +116,9 @@ class AristotleAgent:
         prompt = user_message or ""
 
         with tempfile.TemporaryDirectory() as td:
-            download_dir = Path(td)
             inf = AristotleInference(
                 model_name=self._model_name,
                 project_dir=self.worktree_path,
-                download_dir=download_dir,
                 poll_interval=self._poll_interval,
                 max_wait_seconds=self._max_wait_seconds,
                 on_event=self._on_event,
@@ -132,8 +130,15 @@ class AristotleAgent:
             result = await inf.complete()
             self._messages = inf.get_messages()
 
-            landed = self._overlay_result(download_dir)
-            if landed:
+            # Explicit, retrying download — landing must not be best-effort, or
+            # run_task sees an empty worktree and reports a spurious failure.
+            root = await inf.download_result(td)
+            if root is None:
+                raise RuntimeError(
+                    f"Agent {self.id}: Aristotle task finished "
+                    f"({inf.last_status}) but its result could not be downloaded"
+                )
+            if self._overlay_from(root):
                 self._commit(prompt or "formalize target")
             else:
                 logger.warning("Agent %s: Aristotle returned no project files to land", self.id)
@@ -169,23 +174,15 @@ class AristotleAgent:
     # Landing Aristotle's output into the worktree
     # ------------------------------------------------------------------
 
-    def _overlay_result(self, download_dir: Path) -> bool:
-        """Copy Aristotle's returned project files over the worktree.
-
-        The backend extracts the result tarball as ``download_dir/<root>/…``
-        (a single top-level project directory). We overlay every file from
-        there onto the worktree at the same relative path; git then sees only
-        genuine changes. Returns True if at least one file was copied.
+    def _overlay_from(self, root: Path) -> bool:
+        """Copy Aristotle's returned project files (under ``root``) over the
+        worktree at the same relative paths; git then sees only genuine
+        changes. Skips dirs, symlinks, and ``.git``/``.lake``. Returns True if
+        at least one file was copied.
         """
-        roots = [p for p in download_dir.iterdir() if p.is_dir()]
-        if not roots:
-            return False
-        # Prefer the conventional ``*_aristotle`` root; else the sole directory.
-        root = next((p for p in roots if p.name.endswith("_aristotle")), roots[0])
-
         copied = 0
         for src in root.rglob("*"):
-            if src.is_dir():
+            if src.is_dir() or src.is_symlink():
                 continue
             rel = src.relative_to(root)
             if rel.parts and rel.parts[0] in _SKIP_TOP:

--- a/autoform/bot/aristotle_agent.py
+++ b/autoform/bot/aristotle_agent.py
@@ -1,0 +1,230 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""AristotleAgent — a worker that solves a target with Harmonic's Aristotle.
+
+This is the "Mode B" integration of Aristotle into the AutoformBot worker tier.
+Rather than driving a turn-based tool-calling agent loop, an ``AristotleAgent``
+hands its *whole worktree* (a Lean project) plus the task description to
+Aristotle, which runs its own internal tools and returns finished files; the
+agent lands those files in the worktree and commits them.
+
+Crucially it **duck-types the surface of** ``core.agent.Agent`` that
+``ConcurrentAgents.run_task`` depends on (``id``, ``worktree_path``, async
+``call``, ``reset``, ``set_trace``, ``total_turns``, ``messages``). So the
+existing race/rebase/build/review/merge machinery runs **unchanged** — only the
+"produce code in the worktree" step is swapped. The build (``lake build``),
+reviewer (an LLM agent), and merge queue all operate on the worktree via git
+and are model-agnostic, so they don't care that Aristotle wrote the code.
+
+In-flight steering (the ``steer`` callback on ``AristotleInference``) flows
+through here, so a Hermes-style reviewer can redirect a running Aristotle task.
+
+Limitations are inherited from the backend (see ``core/inference/sdk/aristotle.py``):
+Aristotle is job-based and slow (minutes–hours), so racing many Aristotle
+workers is expensive; prefer ``min_agents_per_task: 1``.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from core.inference.sdk.aristotle import AristotleInference, EventObserver, SteerCallback
+
+logger = logging.getLogger(__name__)
+
+# Credit Aristotle as the author of the Lean it writes (committer stays the
+# pipeline identity so git history is well-formed).
+_ARISTOTLE_AUTHOR = "Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>"
+_COMMITTER_NAME = "autoform-bot"
+_COMMITTER_EMAIL = "autoform-bot@users.noreply.github.com"
+
+# Files/dirs never copied back from Aristotle's returned project.
+_SKIP_TOP = {".git", ".lake"}
+
+DEFAULT_WORKER_SYSTEM_PROMPT = (
+    "You are an expert Lean 4 / Mathlib formalizer. The provided project is a "
+    "Lean library; formalize the requested target into it, writing idiomatic, "
+    "compiling Lean 4. Do not use `sorry`, `admit`, or new axioms. Make the "
+    "project build with `lake build`."
+)
+
+
+class AristotleAgent:
+    """A drop-in worker (duck-typed ``Agent``) backed by Aristotle.
+
+    Args:
+        id: Agent id (used by the coordinator / traces).
+        worktree_path: The agent's git worktree — bundled to Aristotle as the
+            project context, and where returned files are landed + committed.
+        model_name: Aristotle model identifier (tracing only).
+        system_prompt: System prompt sent with each submission.
+        poll_interval / max_wait_seconds: Forwarded to ``AristotleInference``.
+        on_event / steer: Optional observation / in-flight steering callbacks.
+    """
+
+    def __init__(
+        self,
+        *,
+        id: str,
+        worktree_path: Path | str,
+        model_name: str = "aristotle",
+        system_prompt: str = DEFAULT_WORKER_SYSTEM_PROMPT,
+        poll_interval: int = 20,
+        max_wait_seconds: float | None = 5400,
+        on_event: EventObserver | None = None,
+        steer: SteerCallback | None = None,
+    ) -> None:
+        self.id = id
+        self.worktree_path = Path(worktree_path)
+        self._model_name = model_name
+        self._system_prompt = system_prompt
+        self._poll_interval = poll_interval
+        self._max_wait_seconds = max_wait_seconds
+        self._on_event = on_event
+        self._steer = steer
+
+        # Agent-surface state expected by run_task.
+        self.total_turns = 0
+        self._messages: list[dict[str, Any]] = []
+        self._trace: Any | None = None
+
+    # ------------------------------------------------------------------
+    # Agent surface used by ConcurrentAgents.run_task
+    # ------------------------------------------------------------------
+
+    async def call(self, user_message: str | None = None) -> str:
+        """Submit the worktree + task to Aristotle; land + commit the result.
+
+        Returns Aristotle's natural-language ``output_summary`` (non-empty), so
+        run_task treats the turn as productive. Returns ``""`` only if nothing
+        usable came back, which run_task surfaces as a failed attempt.
+        """
+        self.total_turns += 1
+        prompt = user_message or ""
+
+        with tempfile.TemporaryDirectory() as td:
+            download_dir = Path(td)
+            inf = AristotleInference(
+                model_name=self._model_name,
+                project_dir=self.worktree_path,
+                download_dir=download_dir,
+                poll_interval=self._poll_interval,
+                max_wait_seconds=self._max_wait_seconds,
+                on_event=self._on_event,
+                steer=self._steer,
+            )
+            inf.set_system_prompt(self._system_prompt)
+            inf.add_user_message(prompt)
+
+            result = await inf.complete()
+            self._messages = inf.get_messages()
+
+            landed = self._overlay_result(download_dir)
+            if landed:
+                self._commit(prompt or "formalize target")
+            else:
+                logger.warning("Agent %s: Aristotle returned no project files to land", self.id)
+
+        return (result.text or "").strip()
+
+    def reset(self) -> None:
+        self.total_turns = 0
+        self._messages = []
+
+    def set_trace(self, trace: Any | None) -> None:
+        self._trace = trace
+
+    @property
+    def messages(self) -> list[dict[str, Any]]:
+        return self._messages
+
+    # ------------------------------------------------------------------
+    # Landing Aristotle's output into the worktree
+    # ------------------------------------------------------------------
+
+    def _overlay_result(self, download_dir: Path) -> bool:
+        """Copy Aristotle's returned project files over the worktree.
+
+        The backend extracts the result tarball as ``download_dir/<root>/…``
+        (a single top-level project directory). We overlay every file from
+        there onto the worktree at the same relative path; git then sees only
+        genuine changes. Returns True if at least one file was copied.
+        """
+        roots = [p for p in download_dir.iterdir() if p.is_dir()]
+        if not roots:
+            return False
+        # Prefer the conventional ``*_aristotle`` root; else the sole directory.
+        root = next((p for p in roots if p.name.endswith("_aristotle")), roots[0])
+
+        copied = 0
+        for src in root.rglob("*"):
+            if src.is_dir():
+                continue
+            rel = src.relative_to(root)
+            if rel.parts and rel.parts[0] in _SKIP_TOP:
+                continue
+            dest = self.worktree_path / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+            copied += 1
+        return copied > 0
+
+    def _commit(self, summary: str) -> None:
+        """Stage everything and commit, crediting Aristotle as author.
+
+        No-ops cleanly if Aristotle's output was identical to the worktree.
+        """
+        wt = str(self.worktree_path)
+        subprocess.run(["git", "add", "-A"], cwd=wt, check=False)
+        # Nothing staged → nothing to commit (run_task then treats it as no progress).
+        if subprocess.run(["git", "diff", "--cached", "--quiet"], cwd=wt).returncode == 0:
+            return
+        msg = f"Aristotle: {summary[:72]}"
+        trailer = "\n\nCo-authored-by: " + _ARISTOTLE_AUTHOR
+        subprocess.run(
+            [
+                "git",
+                "-c", f"user.name={_COMMITTER_NAME}",
+                "-c", f"user.email={_COMMITTER_EMAIL}",
+                "commit",
+                "--author", _ARISTOTLE_AUTHOR,
+                "-m", msg + trailer,
+            ],
+            cwd=wt,
+            check=False,
+        )
+
+
+def create_aristotle_agents(
+    *,
+    worktrees: list[Path],
+    id_prefix: str = "aristotle",
+    system_prompt: str = DEFAULT_WORKER_SYSTEM_PROMPT,
+    poll_interval: int = 20,
+    max_wait_seconds: float | None = 5400,
+    on_event: EventObserver | None = None,
+    steer: SteerCallback | None = None,
+) -> list[AristotleAgent]:
+    """Build one ``AristotleAgent`` per worktree (the Mode-B analog of the
+    LLM-agent pool's worker construction)."""
+    return [
+        AristotleAgent(
+            id=f"{id_prefix}-{i}",
+            worktree_path=wt,
+            system_prompt=system_prompt,
+            poll_interval=poll_interval,
+            max_wait_seconds=max_wait_seconds,
+            on_event=on_event,
+            steer=steer,
+        )
+        for i, wt in enumerate(worktrees)
+    ]

--- a/autoform/bot/aristotle_agent_test.py
+++ b/autoform/bot/aristotle_agent_test.py
@@ -1,0 +1,158 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for AristotleAgent — the Mode-B Aristotle worker.
+
+Uses a fake ``AristotleInference`` (no network/key) that simulates the backend
+extracting a result project into ``download_dir``, plus a real temporary git
+repo + worktree so the land/commit/merge path is exercised for real.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import types
+from pathlib import Path
+
+import pytest
+
+from core.task import Task
+from core.coordination.concurrent_agents import ConcurrentAgents
+from core import worktree
+from .aristotle_agent import AristotleAgent, create_aristotle_agents
+
+
+# ---------------------------------------------------------------------------
+# Fake backend: simulates submit → returns a project with one new .lean file
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_inference(generated: dict[str, str]):
+    """Return a fake AristotleInference class that writes ``generated`` (relpath
+    → contents) into download_dir/<root>/ on complete()."""
+
+    class FakeInference:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self._download_dir = Path(kwargs["download_dir"])
+            self._u = ""
+
+        def set_system_prompt(self, p):
+            self._sys = p
+
+        def add_user_message(self, c):
+            self._u = c
+
+        def get_messages(self):
+            return [{"role": "user", "content": self._u}, {"role": "assistant", "content": "done"}]
+
+        async def complete(self):
+            root = self._download_dir / "proj_aristotle"
+            for rel, content in generated.items():
+                dest = root / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_text(content)
+            return types.SimpleNamespace(text="Formalized the target.")
+
+    return FakeInference
+
+
+def _git(args, cwd):
+    return subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+        cwd=cwd, capture_output=True, text=True,
+    )
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-b", "main"], root)
+    (root / "README.md").write_text("base\n")
+    _git(["add", "-A"], root)
+    _git(["commit", "-m", "init"], root)
+
+
+# ---------------------------------------------------------------------------
+# call(): lands files + commits, crediting Aristotle
+# ---------------------------------------------------------------------------
+
+
+class TestCall:
+    @pytest.mark.asyncio
+    async def test_call_lands_and_commits(self, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        wt = worktree.create_worktree(repo, "wt0", worktrees_dir=tmp_path / "worktrees")
+
+        monkeypatch.setattr(
+            "autoform.bot.aristotle_agent.AristotleInference",
+            _make_fake_inference({"MyLib/Generated.lean": "theorem t : 1 = 1 := rfl\n"}),
+        )
+        agent = AristotleAgent(id="a0", worktree_path=wt)
+        text = await agent.call("formalize theorem t")
+
+        assert "Formalized" in text
+        assert (wt / "MyLib" / "Generated.lean").exists()
+        assert agent.total_turns == 1
+        assert agent.messages  # populated from inference
+        # A commit landed, authored by Aristotle.
+        author = _git(["log", "-1", "--format=%an <%ae>"], wt).stdout.strip()
+        assert "Aristotle (Harmonic)" in author
+        # Co-author trailer present.
+        body = _git(["log", "-1", "--format=%b"], wt).stdout
+        assert "Co-authored-by: Aristotle (Harmonic)" in body
+
+    @pytest.mark.asyncio
+    async def test_call_no_files_no_commit(self, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        wt = worktree.create_worktree(repo, "wt1", worktrees_dir=tmp_path / "worktrees")
+        before = _git(["rev-parse", "HEAD"], wt).stdout.strip()
+
+        monkeypatch.setattr(
+            "autoform.bot.aristotle_agent.AristotleInference",
+            _make_fake_inference({}),  # returns no files
+        )
+        agent = AristotleAgent(id="a1", worktree_path=wt)
+        await agent.call("do nothing")
+        after = _git(["rev-parse", "HEAD"], wt).stdout.strip()
+        assert before == after  # no commit created
+
+    def test_create_aristotle_agents(self, tmp_path):
+        agents = create_aristotle_agents(worktrees=[tmp_path / "a", tmp_path / "b"])
+        assert [a.id for a in agents] == ["aristotle-0", "aristotle-1"]
+        assert all(isinstance(a, AristotleAgent) for a in agents)
+
+
+# ---------------------------------------------------------------------------
+# run_task integration: AristotleAgent drives the real race/build/merge loop
+# ---------------------------------------------------------------------------
+
+
+class TestRunTaskIntegration:
+    @pytest.mark.asyncio
+    async def test_aristotle_agent_merges_to_main(self, tmp_path, monkeypatch):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        wt = worktree.create_worktree(repo, "wt2", worktrees_dir=tmp_path / "worktrees")
+
+        monkeypatch.setattr(
+            "autoform.bot.aristotle_agent.AristotleInference",
+            _make_fake_inference({"Generated.lean": "theorem t : 2 = 2 := rfl\n"}),
+        )
+        agent = AristotleAgent(id="ar0", worktree_path=wt)
+
+        # Base ConcurrentAgents: build() is a no-op pass (no Mathlib needed),
+        # no reviewer → straight to merge. This is the real worker-tier loop.
+        ca = ConcurrentAgents(repo_root=repo)
+        task = Task(id="T1", title="t", description="formalize theorem t")
+        result = await ca.run_task(task, [agent], get_reviewer=None)
+
+        assert result.success
+        assert result.winner_id == "ar0"
+        # The file Aristotle wrote is now on main.
+        on_main = _git(["show", "main:Generated.lean"], repo).stdout
+        assert "2 = 2" in on_main

--- a/autoform/bot/aristotle_agent_test.py
+++ b/autoform/bot/aristotle_agent_test.py
@@ -22,7 +22,7 @@ import pytest
 from core.task import Task
 from core.coordination.concurrent_agents import ConcurrentAgents
 from core import worktree
-from .aristotle_agent import AristotleAgent, create_aristotle_agents
+from .aristotle_agent import AristotleAgent, create_aristotle_agents, create_aristotle_pool
 
 
 # ---------------------------------------------------------------------------
@@ -125,6 +125,21 @@ class TestCall:
         agents = create_aristotle_agents(worktrees=[tmp_path / "a", tmp_path / "b"])
         assert [a.id for a in agents] == ["aristotle-0", "aristotle-1"]
         assert all(isinstance(a, AristotleAgent) for a in agents)
+
+    @pytest.mark.asyncio
+    async def test_create_aristotle_pool_builds_worktrees(self, tmp_path):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        pool = create_aristotle_pool(repo, num_agents=2, agent_id_prefix="rank0", run_id="run-test")
+
+        assert pool.size == 2
+        agents = pool.checkout(2)
+        assert all(isinstance(a, AristotleAgent) for a in agents)
+        assert all(Path(a.worktree_path).is_dir() for a in agents)  # worktrees created
+        assert pool.get_reviewer(agents[0].id) is None  # no reviewers in Mode B
+        # Pool lifecycle no-ops don't raise.
+        await pool.initialize()
+        await pool.shutdown()
 
 
 # ---------------------------------------------------------------------------

--- a/autoform/bot/aristotle_agent_test.py
+++ b/autoform/bot/aristotle_agent_test.py
@@ -30,14 +30,19 @@ from .aristotle_agent import AristotleAgent, create_aristotle_agents, create_ari
 # ---------------------------------------------------------------------------
 
 
-def _make_fake_inference(generated: dict[str, str]):
-    """Return a fake AristotleInference class that writes ``generated`` (relpath
-    → contents) into download_dir/<root>/ on complete()."""
+def _make_fake_inference(generated: dict[str, str] | None, *, download_ok: bool = True):
+    """Return a fake AristotleInference class.
+
+    ``download_result`` writes ``generated`` (relpath → contents) into a
+    ``proj_aristotle`` root and returns it (or ``None`` when ``download_ok``
+    is False, simulating an exhausted-retry download failure).
+    """
 
     class FakeInference:
+        last_status = "COMPLETE"
+
         def __init__(self, **kwargs):
             self.kwargs = kwargs
-            self._download_dir = Path(kwargs["download_dir"])
             self._u = ""
 
         def set_system_prompt(self, p):
@@ -50,12 +55,18 @@ def _make_fake_inference(generated: dict[str, str]):
             return [{"role": "user", "content": self._u}, {"role": "assistant", "content": "done"}]
 
         async def complete(self):
-            root = self._download_dir / "proj_aristotle"
-            for rel, content in generated.items():
+            return types.SimpleNamespace(text="Formalized the target.")
+
+        async def download_result(self, dest_dir, *, retries=3, retry_delay=5.0):
+            if not download_ok:
+                return None
+            root = Path(dest_dir) / "proj_aristotle"
+            root.mkdir(parents=True, exist_ok=True)
+            for rel, content in (generated or {}).items():
                 dest = root / rel
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 dest.write_text(content)
-            return types.SimpleNamespace(text="Formalized the target.")
+            return root
 
     return FakeInference
 
@@ -112,14 +123,32 @@ class TestCall:
         wt = worktree.create_worktree(repo, "wt1", worktrees_dir=tmp_path / "worktrees")
         before = _git(["rev-parse", "HEAD"], wt).stdout.strip()
 
+        # Download succeeds but the returned project has no changed files.
         monkeypatch.setattr(
             "autoform.bot.aristotle_agent.AristotleInference",
-            _make_fake_inference({}),  # returns no files
+            _make_fake_inference({}),
         )
         agent = AristotleAgent(id="a1", worktree_path=wt)
         await agent.call("do nothing")
         after = _git(["rev-parse", "HEAD"], wt).stdout.strip()
         assert before == after  # no commit created
+
+    @pytest.mark.asyncio
+    async def test_call_raises_on_download_failure(self, tmp_path, monkeypatch):
+        """The bug that made a real run report a spurious failure: a terminal
+        task whose result couldn't be downloaded must raise loudly, not land
+        nothing silently."""
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        wt = worktree.create_worktree(repo, "wt_dl", worktrees_dir=tmp_path / "worktrees")
+
+        monkeypatch.setattr(
+            "autoform.bot.aristotle_agent.AristotleInference",
+            _make_fake_inference({"X.lean": "x"}, download_ok=False),
+        )
+        agent = AristotleAgent(id="a2", worktree_path=wt)
+        with pytest.raises(RuntimeError, match="could not be downloaded"):
+            await agent.call("prove")
 
     def test_create_aristotle_agents(self, tmp_path):
         agents = create_aristotle_agents(worktrees=[tmp_path / "a", tmp_path / "b"])

--- a/autoform/bot/aristotle_agent_test.py
+++ b/autoform/bot/aristotle_agent_test.py
@@ -22,7 +22,7 @@ import pytest
 from core.task import Task
 from core.coordination.concurrent_agents import ConcurrentAgents
 from core import worktree
-from .aristotle_agent import AristotleAgent, create_aristotle_agents, create_aristotle_pool
+from .aristotle_agent import AristotleAgent, create_aristotle_agents, create_aristotle_pool, make_claude_steer
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +174,54 @@ class TestCall:
 # ---------------------------------------------------------------------------
 # run_task integration: AristotleAgent drives the real race/build/merge loop
 # ---------------------------------------------------------------------------
+
+
+def _ev(type_name: str, content: str = ""):
+    """Minimal stand-in for an aristotlelib Event (what a steer callback sees)."""
+    return types.SimpleNamespace(event_type=types.SimpleNamespace(name=type_name), content=content)
+
+
+class TestClaudeSteer:
+    @pytest.mark.asyncio
+    async def test_steer_fires_then_rate_limits(self, monkeypatch):
+        calls = {"n": 0}
+
+        def fake_cli(prompt, *, timeout=180):
+            calls["n"] += 1
+            return '{"steer": true, "reason": "forcing k = top", "prompt": "Do not pin k; keep it general."}'
+
+        monkeypatch.setattr("autoform.bot.aristotle_agent._claude_cli", fake_cli)
+        steer = make_claude_steer("generalize k", min_gap_s=120.0, max_steers=3)
+        evs = [_ev("EDITING_FILE")]
+
+        p1 = await steer(evs, None)
+        assert p1 and "keep it general" in p1
+        # immediate second call is rate-limited (no extra CLI call, no steer)
+        assert await steer(evs, None) is None
+        assert calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_steer_respects_no_steer_verdict(self, monkeypatch):
+        monkeypatch.setattr(
+            "autoform.bot.aristotle_agent._claude_cli",
+            lambda prompt, **k: '{"steer": false, "reason": "on track", "prompt": ""}',
+        )
+        steer = make_claude_steer("g")
+        assert await steer([_ev("EDITING_FILE")], None) is None
+
+    @pytest.mark.asyncio
+    async def test_steer_ignores_irrelevant_events(self, monkeypatch):
+        called = {"n": 0}
+
+        def fake_cli(prompt, *, timeout=180):
+            called["n"] += 1
+            return '{"steer": false}'
+
+        monkeypatch.setattr("autoform.bot.aristotle_agent._claude_cli", fake_cli)
+        steer = make_claude_steer("g")
+        # BUILDING is not a judged event type -> no CLI call, no steer
+        assert await steer([_ev("BUILDING")], None) is None
+        assert called["n"] == 0
 
 
 class TestRunTaskIntegration:

--- a/autoform/bot/config.py
+++ b/autoform/bot/config.py
@@ -29,6 +29,7 @@ class PipelineConfig:
     max_agents_per_task: int
     max_concurrent_llm_calls: int
     model: str
+    solver: str = "agent"
     num_repls_per_node: int | None = None
     pick_strategy: NodePickStrategy = NodePickStrategy.BIGGEST_FIRST
     lib_name: str = "Formalization"
@@ -78,6 +79,7 @@ class PipelineConfig:
             max_agents_per_task=workers_config.get("max_agents_per_task", 1),
             max_concurrent_llm_calls=workers_config.get("max_concurrent_llm_calls", 2),
             model=llm_config.get("model", "Opus 4.6"),
+            solver=llm_config.get("solver", "agent"),
             num_repls_per_node=workers_config.get("num_repls_per_node"),
             pick_strategy=NodePickStrategy(raw_strategy),
             lib_name=workspace_config.get("lib_name", "Formalization"),

--- a/autoform/bot/main.py
+++ b/autoform/bot/main.py
@@ -160,6 +160,7 @@ def _build_worker_node(
         trace_store=trace_store,
         run_id=run_id,
         max_review_cycles=pipeline_config.max_review_cycles,
+        solver=pipeline_config.solver,
     )
 
 

--- a/autoform/bot/worker_node.py
+++ b/autoform/bot/worker_node.py
@@ -65,6 +65,7 @@ class LeanWorkerNode(WorkerNode):
         trace_store: TraceStore | None = None,
         run_id: str | None = None,
         max_review_cycles: int = 0,
+        solver: str = "agent",
     ) -> None:
         super().__init__(rank=rank, host=host, port=port)
         self._code_path = code_path
@@ -77,6 +78,7 @@ class LeanWorkerNode(WorkerNode):
         self._trace_store = trace_store
         self._run_id = run_id
         self._max_review_cycles = max_review_cycles
+        self._solver = solver
         self._pool: AgentPool | None = None
         self._concurrent: ConcurrentAgents | None = None
         self._merge_client: MergeQueueClient | None = None
@@ -88,19 +90,36 @@ class LeanWorkerNode(WorkerNode):
         return len(self._pool.available()) if self._pool is not None else 0
 
     async def initialize(self) -> None:
-        """Create pool and warm up all agents (REPL + LSP start, worktrees ready)."""
-        self._pool = create_lean_pool(
-            repo_root=self._code_path,
-            num_agents=self._num_agents,
-            inference_factory=self._inference_factory,
-            worker_def=self._worker_def,
-            reviewer_def=self._reviewer_def,
-            agent_id_prefix=f"rank{self.rank}",
-            allowed_paths=self._allowed_paths,
-            trace_store=self._trace_store,
-            repl_config=self._repl_config,
-            run_id=self._run_id,
-        )
+        """Create pool and warm up all agents (REPL + LSP start, worktrees ready).
+
+        When ``solver == "aristotle"`` the worker pool is built from
+        ``AristotleAgent``s (Mode B): same worktrees, but Aristotle solves each
+        target instead of a tool-calling agent. The build gate and merge path
+        below are unchanged.
+        """
+        if self._solver == "aristotle":
+            from .aristotle_agent import create_aristotle_pool
+
+            logger.info("[rank %d] solver=aristotle: building Aristotle worker pool", self.rank)
+            self._pool = create_aristotle_pool(
+                repo_root=self._code_path,
+                num_agents=self._num_agents,
+                agent_id_prefix=f"rank{self.rank}",
+                run_id=self._run_id,
+            )
+        else:
+            self._pool = create_lean_pool(
+                repo_root=self._code_path,
+                num_agents=self._num_agents,
+                inference_factory=self._inference_factory,
+                worker_def=self._worker_def,
+                reviewer_def=self._reviewer_def,
+                agent_id_prefix=f"rank{self.rank}",
+                allowed_paths=self._allowed_paths,
+                trace_store=self._trace_store,
+                repl_config=self._repl_config,
+                run_id=self._run_id,
+            )
         self._merge_client = MergeQueueClient(
             host=self.host,
             port=self.port + _MERGE_PORT_OFFSET,

--- a/core/inference/client.py
+++ b/core/inference/client.py
@@ -24,6 +24,7 @@ class Backend(StrEnum):
     GEMINI = "gemini"
     OPENAI_RESPONSE = "openai_response"
     OPENAI_CHAT = "openai_chat"
+    ARISTOTLE = "aristotle"
 
     def create(
         self, *, api_key: str, url: str, model_name: str, is_local: bool, pricing: ModelPricing | None = None
@@ -64,6 +65,15 @@ class Backend(StrEnum):
 
                 client = AsyncOpenAI(api_key=api_key, base_url=url)
                 return OpenAIChatInference(client, model_name=model_name, is_local=is_local, pricing=pricing)
+
+            case Backend.ARISTOTLE:
+                import aristotlelib
+
+                from .sdk.aristotle import AristotleInference
+
+                # aristotlelib reads the key from a module-global / env var.
+                aristotlelib.set_api_key(api_key)
+                return AristotleInference(model_name=model_name)
 
             case _:
                 raise ValueError(f"Unknown backend: {self}")
@@ -210,6 +220,24 @@ class Gemini_3_1_Pro(Model):
     provider_url = ""
     env_key = "GEMINI_API_KEY"
     backend = Backend.GEMINI
+
+
+# ---------------------------------------------------------------------------
+# Aristotle (Harmonic) — autonomous formal-reasoning agent, not a chat model.
+# See core/inference/sdk/aristotle.py for the job-based integration and its
+# limitations (no per-turn tool calls, no in-flight steering, no token usage).
+# ---------------------------------------------------------------------------
+
+
+class Aristotle(Model):
+    model_name = "aristotle"
+    abbreviation = "Aristotle"
+    # Aristotle bills by compute, not tokens, so per-token pricing does not
+    # apply; report zero so cost accounting treats it as untracked.
+    pricing = _FREE
+    provider_url = ""  # aristotlelib targets its own base URL internally
+    env_key = "ARISTOTLE_API_KEY"
+    backend = Backend.ARISTOTLE
 
 
 # ---------------------------------------------------------------------------

--- a/core/inference/sdk/aristotle.py
+++ b/core/inference/sdk/aristotle.py
@@ -30,12 +30,17 @@ Honest limitations (documented for callers):
 * **No per-turn tool calling.** Aristotle runs its own tools internally, so
   ``tools`` passed by the agent loop are ignored and ``TurnResult.tool_calls``
   is always empty. Drive Aristotle with plain instructions, not tool schemas.
-* **No in-flight steering.** A running task can only be observed (events) or
-  cancelled; to redirect, cancel/finish then ``ask`` again. This adapter
-  steers between turns, not mid-task.
 * **No token usage / prompt caching.** Aristotle bills by compute, not
   tokens, so ``TokenUsage`` is reported as zeros and ``CacheConfig`` is a
   no-op.
+
+In-flight steering IS supported. While a task is running you can issue
+``project.ask(...)`` to redirect the live session (this is what Marathon's
+"Hermes" watcher does). Pass a ``steer`` callback to observe the event stream
+as it arrives and optionally return a steering prompt, which is injected via
+``project.ask`` while the task is still in flight. An ``on_event`` callback is
+also available for pure observation (progress, logging). Between-turn steering
+via follow-up ``complete()`` calls works too (each reuses the live session).
 
 The status-classification vocabulary (``IN_FLIGHT`` / ``CONTINUABLE`` /
 terminal) mirrors the design used in Marathon (https://github.com/Deicyde/marathon),
@@ -48,6 +53,7 @@ from __future__ import annotations
 import logging
 import tarfile
 import time
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
@@ -61,6 +67,18 @@ from ..protocol import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Callback contracts for live observation / steering. ``Any`` stands for
+# aristotlelib's ``Event`` / ``AgentTask`` (kept untyped so the module imports
+# without the optional ``aristotlelib`` dependency installed).
+#
+# - EventObserver: called once per new event as it arrives during a run.
+# - SteerCallback: called with each batch of new events plus the running task;
+#   return a non-empty prompt to redirect the live task via ``project.ask``,
+#   or ``None``/empty to let it continue. This is the upstreamable
+#   generalization of Marathon's Hermes watcher.
+EventObserver = Callable[[Any], Awaitable[None]]
+SteerCallback = Callable[[list[Any], Any], Awaitable[str | None]]
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +130,13 @@ class AristotleInference(InferenceProtocol):
         poll_interval: Seconds between status polls while a task runs.
         max_wait_seconds: Optional ceiling on how long to wait for a single
             task; ``None`` waits indefinitely.
+        on_event: Optional async callback invoked once per new event as the
+            task runs (observation only — progress bars, logging).
+        steer: Optional async callback for in-flight steering. Called with
+            ``(new_events, task)`` on each poll that surfaces new events; if it
+            returns a non-empty prompt and the task is still in flight, the
+            prompt is injected via ``project.ask`` to redirect the live
+            session, and polling switches to the resulting task.
         lib: The ``aristotlelib`` module (injected for testing). When ``None``
             it is imported lazily on first use.
     """
@@ -124,6 +149,8 @@ class AristotleInference(InferenceProtocol):
         download_dir: Path | str | None = None,
         poll_interval: int = 10,
         max_wait_seconds: float | None = None,
+        on_event: EventObserver | None = None,
+        steer: SteerCallback | None = None,
         lib: Any | None = None,
     ) -> None:
         super().__init__()
@@ -132,6 +159,9 @@ class AristotleInference(InferenceProtocol):
         self._download_dir = Path(download_dir) if download_dir is not None else None
         self._poll_interval = poll_interval
         self._max_wait_seconds = max_wait_seconds
+        self._on_event = on_event
+        self._steer = steer
+
         self._lib = lib
 
         # Conversation state. ``_messages`` is a simple role/content log used
@@ -141,6 +171,7 @@ class AristotleInference(InferenceProtocol):
         self._messages: list[dict[str, Any]] = []
         self._project: Any | None = None
         self._last_status: str = ""
+        self._steer_count: int = 0
 
     # ------------------------------------------------------------------
     # Lazy SDK access
@@ -260,10 +291,35 @@ class AristotleInference(InferenceProtocol):
             )
         return await self._project.ask(user_content)
 
+    async def _fetch_new_events(self, task: Any, seen: set[str]) -> list[Any]:
+        """Return events on ``task`` not already in ``seen``, oldest-first.
+
+        Updates ``seen`` in place. Best-effort: a transient fetch error
+        returns no new events rather than aborting the run.
+        """
+        try:
+            events, _ = await task.get_events(limit=50, newest_first=True)
+        except Exception as err:  # pragma: no cover - transient API hiccup
+            logger.debug("event fetch failed (continuing): %s", err)
+            return []
+        fresh = [e for e in events if getattr(e, "event_id", None) not in seen]
+        for e in fresh:
+            seen.add(getattr(e, "event_id", None))
+        fresh.reverse()
+        return fresh
+
     async def _poll_to_terminal(self, task: Any) -> Any:
-        """Poll ``task.refresh`` until it leaves the in-flight statuses."""
+        """Poll ``task`` until it leaves the in-flight statuses.
+
+        When ``on_event``/``steer`` are configured, the event stream is polled
+        alongside status. A ``steer`` callback that returns a prompt while the
+        task is still in flight injects it via ``project.ask`` (in-flight
+        steering) and polling switches to the resulting task.
+        """
         import asyncio
 
+        watching = self._on_event is not None or self._steer is not None
+        seen: set[str] = set()
         start = time.monotonic()
         while _status_value(task.status) in _IN_FLIGHT_STATUSES:
             if self._max_wait_seconds is not None and (time.monotonic() - start) > self._max_wait_seconds:
@@ -275,6 +331,31 @@ class AristotleInference(InferenceProtocol):
                 break
             await asyncio.sleep(self._poll_interval)
             await task.refresh()
+
+            if not watching:
+                continue
+
+            new_events = await self._fetch_new_events(task, seen)
+            for event in new_events:
+                if self._on_event is not None:
+                    await self._on_event(event)
+
+            if self._steer is not None and new_events:
+                prompt = await self._steer(new_events, task)
+                if prompt:
+                    # Only redirect a task that is still running; ``ask`` on an
+                    # idle project would start an unrelated task instead.
+                    await task.refresh()
+                    if _status_value(task.status) in _IN_FLIGHT_STATUSES and self._project is not None:
+                        steered = await self._project.ask(prompt)
+                        self._steer_count += 1
+                        logger.info(
+                            "Steered Aristotle in-flight (#%d): %s",
+                            self._steer_count,
+                            prompt[:120],
+                        )
+                        # Follow the live session onto the new task.
+                        task = steered
         return task
 
     async def _maybe_download(self) -> str:

--- a/core/inference/sdk/aristotle.py
+++ b/core/inference/sdk/aristotle.py
@@ -1,0 +1,337 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Aristotle (Harmonic) inference backend.
+
+Implements :class:`InferenceProtocol` on top of Harmonic's ``aristotlelib``
+SDK. Aristotle is *not* a turn-based chat model: it is an autonomous formal
+reasoning agent that takes a prompt (and optionally a whole Lean project),
+runs its own internal tools (proof search, Lean builds, file edits), and
+returns finished files plus a natural-language ``output_summary``.
+
+We map that job-based API onto the chat-shaped protocol as follows:
+
+* A single, persistent ``Project`` backs the whole conversation. It is
+  created lazily on the first :meth:`complete` call (optionally bundling a
+  seed Lean project from ``project_dir``).
+* Each :meth:`complete` call submits the latest user turn — the first turn
+  via ``Project.create`` / ``create_from_directory``, every later turn via
+  ``project.ask`` — then polls the resulting ``AgentTask`` to a terminal
+  status. This *is* multi-turn steering: follow-up ``ask`` calls reuse
+  Aristotle's live server-side session (see the ``CONTINUABLE`` statuses).
+* The task's ``output_summary`` becomes the assistant text; the changed Lean
+  files can optionally be downloaded to ``download_dir``.
+
+Honest limitations (documented for callers):
+
+* **No per-turn tool calling.** Aristotle runs its own tools internally, so
+  ``tools`` passed by the agent loop are ignored and ``TurnResult.tool_calls``
+  is always empty. Drive Aristotle with plain instructions, not tool schemas.
+* **No in-flight steering.** A running task can only be observed (events) or
+  cancelled; to redirect, cancel/finish then ``ask`` again. This adapter
+  steers between turns, not mid-task.
+* **No token usage / prompt caching.** Aristotle bills by compute, not
+  tokens, so ``TokenUsage`` is reported as zeros and ``CacheConfig`` is a
+  no-op.
+
+The status-classification vocabulary (``IN_FLIGHT`` / ``CONTINUABLE`` /
+terminal) mirrors the design used in Marathon (https://github.com/Deicyde/marathon),
+a standalone Aristotle driver, distilled here to the minimum this adapter
+needs and depending only on the public ``aristotlelib``.
+"""
+
+from __future__ import annotations
+
+import logging
+import tarfile
+import time
+from pathlib import Path
+from typing import Any
+
+from ..protocol import (
+    InferenceConfig,
+    InferenceProtocol,
+    TokenUsage,
+    ToolResult,
+    ToolSchema,
+    TurnResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Status classification (compared by ``.value`` string, enum-agnostic)
+# ---------------------------------------------------------------------------
+
+# Task is still running on Aristotle's side; keep polling.
+_IN_FLIGHT_STATUSES: frozenset[str] = frozenset({"QUEUED", "IN_PROGRESS"})
+
+# Terminal statuses where Aristotle's server-side session is preserved, so the
+# next turn should *continue* it via ``project.ask`` rather than resubmit.
+# The web UI labels these "Review Suggested" / "Out of Budget"; the SDK
+# documents both as resumable ("Resume by telling Aristotle to continue").
+_CONTINUABLE_STATUSES: frozenset[str] = frozenset({"COMPLETE_WITH_ERRORS", "OUT_OF_BUDGET"})
+
+
+def _status_value(status: Any) -> str:
+    """Return the ``.value`` of a ``TaskStatus`` (or the string itself)."""
+    return str(getattr(status, "value", status))
+
+
+def _map_finish_reason(status_value: str) -> str:
+    """Map a terminal ``TaskStatus`` value to a normalized finish reason."""
+    match status_value:
+        case "COMPLETE" | "COMPLETE_WITH_ERRORS":
+            return "stop"
+        case "OUT_OF_BUDGET":
+            return "length"
+        case "FAILED":
+            return "error"
+        case "CANCELED":
+            return "cancelled"
+        case _:
+            return status_value.lower() or "stop"
+
+
+class AristotleInference(InferenceProtocol):
+    """:class:`InferenceProtocol` backed by Harmonic's Aristotle agent.
+
+    Args:
+        model_name: Identifier recorded on results (Aristotle takes no model
+            parameter; this is purely for tracing/pricing lookup).
+        project_dir: Optional Lean project bundled as context on the first
+            submission (via ``Project.create_from_directory``). When ``None``,
+            the first turn is a bare prompt (``Project.create``).
+        download_dir: Optional directory; when set, each completed turn's
+            result tarball is downloaded and extracted here, and the
+            extraction path is appended to the assistant text.
+        poll_interval: Seconds between status polls while a task runs.
+        max_wait_seconds: Optional ceiling on how long to wait for a single
+            task; ``None`` waits indefinitely.
+        lib: The ``aristotlelib`` module (injected for testing). When ``None``
+            it is imported lazily on first use.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        project_dir: Path | str | None = None,
+        download_dir: Path | str | None = None,
+        poll_interval: int = 10,
+        max_wait_seconds: float | None = None,
+        lib: Any | None = None,
+    ) -> None:
+        super().__init__()
+        self._model_name = model_name
+        self._project_dir = Path(project_dir) if project_dir is not None else None
+        self._download_dir = Path(download_dir) if download_dir is not None else None
+        self._poll_interval = poll_interval
+        self._max_wait_seconds = max_wait_seconds
+        self._lib = lib
+
+        # Conversation state. ``_messages`` is a simple role/content log used
+        # only for tracing; the authoritative state lives in the Aristotle
+        # ``Project`` session held in ``_project``.
+        self._system_prompt: str = ""
+        self._messages: list[dict[str, Any]] = []
+        self._project: Any | None = None
+        self._last_status: str = ""
+
+    # ------------------------------------------------------------------
+    # Lazy SDK access
+    # ------------------------------------------------------------------
+
+    def _aristotlelib(self) -> Any:
+        if self._lib is None:
+            import aristotlelib  # lazy: only required when this backend is used
+
+            self._lib = aristotlelib
+        return self._lib
+
+    # ------------------------------------------------------------------
+    # Protocol: conversation management
+    # ------------------------------------------------------------------
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    def set_system_prompt(self, prompt: str) -> None:
+        self._system_prompt = prompt
+
+    def get_system_prompt(self) -> str:
+        return self._system_prompt
+
+    def add_user_message(self, content: str) -> None:
+        self._messages.append({"role": "user", "content": content})
+
+    def add_tool_results(self, results: list[ToolResult]) -> None:
+        # Aristotle has no per-turn tool-call protocol, so tool results should
+        # not normally arrive. Fold any that do into a plain user message so no
+        # information is silently dropped.
+        for r in results:
+            prefix = "[tool error] " if r.is_error else "[tool result] "
+            self._messages.append({"role": "user", "content": prefix + r.content})
+
+    def reset(self) -> None:
+        # Drop the conversation *and* the Aristotle session so the next turn
+        # starts a fresh project (the system prompt is preserved by contract).
+        self._messages.clear()
+        self._project = None
+        self._last_status = ""
+
+    def get_messages(self) -> list[dict[str, Any]]:
+        msgs: list[dict[str, Any]] = []
+        if self._system_prompt:
+            msgs.append({"role": "system", "content": self._system_prompt})
+        msgs.extend(self._messages)
+        return msgs
+
+    def replace_history(self, summary: str) -> None:
+        self._messages.clear()
+        self._messages.append({"role": "user", "content": f"[Context summary of previous conversation]\n\n{summary}"})
+
+    def replace_messages(self, messages: list[dict[str, Any]]) -> None:
+        self._messages = [m for m in messages if m.get("role") != "system"]
+
+    def cleanup_interrupted(self) -> None:
+        # Strip a trailing assistant turn that never produced text (e.g. an
+        # interrupted poll), and any trailing tool-result messages.
+        while self._messages:
+            last = self._messages[-1]
+            role = last.get("role", "")
+            content = last.get("content", "")
+            if role == "assistant" and (not content or (isinstance(content, str) and not content.strip())):
+                self._messages.pop()
+                continue
+            if role == "user" and isinstance(content, str) and content.startswith(("[tool result] ", "[tool error] ")):
+                self._messages.pop()
+                continue
+            break
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _latest_user_content(self) -> str:
+        for msg in reversed(self._messages):
+            if msg.get("role") == "user":
+                return str(msg.get("content", ""))
+        return ""
+
+    def _initial_prompt(self, user_content: str) -> str:
+        """Prompt for the first submission: system context + first user turn."""
+        if self._system_prompt:
+            return f"{self._system_prompt}\n\n{user_content}".strip()
+        return user_content
+
+    async def _submit(self, user_content: str) -> Any:
+        """Submit ``user_content`` and return the resulting ``AgentTask``.
+
+        First turn creates the project (bundling ``project_dir`` when given);
+        later turns continue the live session via ``project.ask``.
+        """
+        lib = self._aristotlelib()
+        if self._project is None:
+            prompt = self._initial_prompt(user_content)
+            if self._project_dir is not None:
+                self._project = await lib.Project.create_from_directory(
+                    prompt=prompt, project_dir=self._project_dir
+                )
+            else:
+                self._project = await lib.Project.create(prompt=prompt)
+            tasks, _ = await self._project.get_tasks(limit=1, newest_first=True)
+            if not tasks:
+                raise RuntimeError(
+                    f"project {getattr(self._project, 'project_id', '?')} has no AgentTask after submission"
+                )
+            return tasks[0]
+
+        if self._last_status and self._last_status not in _CONTINUABLE_STATUSES:
+            logger.debug(
+                "Continuing Aristotle project after non-continuable status %r; "
+                "ask() starts a new task on the same project.",
+                self._last_status,
+            )
+        return await self._project.ask(user_content)
+
+    async def _poll_to_terminal(self, task: Any) -> Any:
+        """Poll ``task.refresh`` until it leaves the in-flight statuses."""
+        import asyncio
+
+        start = time.monotonic()
+        while _status_value(task.status) in _IN_FLIGHT_STATUSES:
+            if self._max_wait_seconds is not None and (time.monotonic() - start) > self._max_wait_seconds:
+                logger.warning(
+                    "Aristotle task %s exceeded max_wait_seconds=%s; returning last-known state.",
+                    getattr(task, "agent_task_id", "?"),
+                    self._max_wait_seconds,
+                )
+                break
+            await asyncio.sleep(self._poll_interval)
+            await task.refresh()
+        return task
+
+    async def _maybe_download(self) -> str:
+        """Download + extract the result tarball when ``download_dir`` is set.
+
+        Returns a short note to append to the assistant text, or ``""``.
+        """
+        if self._download_dir is None or self._project is None:
+            return ""
+        try:
+            self._download_dir.mkdir(parents=True, exist_ok=True)
+            project_id = getattr(self._project, "project_id", "aristotle")
+            tar_path = self._download_dir / f"{project_id}.tar.gz"
+            await self._project.get_files(destination=tar_path)
+            with tarfile.open(tar_path) as tar:
+                tar.extractall(self._download_dir)  # noqa: S202 - trusted Aristotle output
+            return f"\n\n[Aristotle files extracted to {self._download_dir}]"
+        except Exception as err:  # pragma: no cover - best-effort side channel
+            logger.warning("Failed to download Aristotle result files: %s", err)
+            return f"\n\n[Aristotle file download failed: {err}]"
+
+    # ------------------------------------------------------------------
+    # Protocol: complete
+    # ------------------------------------------------------------------
+
+    async def complete(
+        self,
+        *,
+        tools: list[ToolSchema] | None = None,
+        inference_config: InferenceConfig | None = None,
+    ) -> TurnResult:
+        if tools:
+            logger.debug(
+                "AristotleInference ignores %d tool schema(s): Aristotle runs its own tools internally.",
+                len(tools),
+            )
+
+        user_content = self._latest_user_content()
+        task = await self._submit(user_content)
+        task = await self._poll_to_terminal(task)
+
+        status_value = _status_value(task.status)
+        self._last_status = status_value
+
+        text = (getattr(task, "output_summary", None) or "").strip()
+        text += await self._maybe_download()
+        if not text:
+            text = f"[Aristotle task {status_value.lower()} with no summary]"
+
+        self._messages.append({"role": "assistant", "content": text})
+
+        return TurnResult(
+            text=text,
+            thinking="",
+            tool_calls=[],
+            usage=TokenUsage(),
+            model=self._model_name,
+            call_id=str(getattr(task, "agent_task_id", "")),
+            finish_reason=_map_finish_reason(status_value),
+        )

--- a/core/inference/sdk/aristotle.py
+++ b/core/inference/sdk/aristotle.py
@@ -347,15 +347,21 @@ class AristotleInference(InferenceProtocol):
                     # idle project would start an unrelated task instead.
                     await task.refresh()
                     if _status_value(task.status) in _IN_FLIGHT_STATUSES and self._project is not None:
-                        steered = await self._project.ask(prompt)
-                        self._steer_count += 1
-                        logger.info(
-                            "Steered Aristotle in-flight (#%d): %s",
-                            self._steer_count,
-                            prompt[:120],
-                        )
-                        # Follow the live session onto the new task.
-                        task = steered
+                        try:
+                            steered = await self._project.ask(prompt)
+                        except Exception as err:
+                            # A steer failure (e.g. 429, race with termination)
+                            # must not kill a long run; log and keep polling.
+                            logger.warning("in-flight steer ask() failed (continuing): %s", err)
+                        else:
+                            self._steer_count += 1
+                            logger.info(
+                                "Steered Aristotle in-flight (#%d): %s",
+                                self._steer_count,
+                                prompt[:120],
+                            )
+                            # Follow the live session onto the new task.
+                            task = steered
         return task
 
     async def _maybe_download(self) -> str:

--- a/core/inference/sdk/aristotle.py
+++ b/core/inference/sdk/aristotle.py
@@ -383,6 +383,55 @@ class AristotleInference(InferenceProtocol):
             logger.warning("Failed to download Aristotle result files: %s", err)
             return f"\n\n[Aristotle file download failed: {err}]"
 
+    @property
+    def last_status(self) -> str:
+        """Terminal ``TaskStatus`` value of the most recent ``complete()``."""
+        return self._last_status
+
+    async def download_result(
+        self,
+        dest_dir: Path | str,
+        *,
+        retries: int = 3,
+        retry_delay: float = 5.0,
+    ) -> Path | None:
+        """Download + extract the project's result, returning the extracted
+        project-root directory (or ``None`` if unavailable after retries).
+
+        Unlike the best-effort ``_maybe_download`` side channel, this is
+        explicit and **retries**: when a task first reaches a terminal status
+        the result files can be momentarily unavailable, so a single
+        ``get_files`` can transiently fail. Callers that must land the output
+        (e.g. the Aristotle worker) should use this and treat ``None`` as a
+        hard failure.
+        """
+        import asyncio
+
+        if self._project is None:
+            return None
+        dest = Path(dest_dir)
+        dest.mkdir(parents=True, exist_ok=True)
+        last_err: Exception | None = None
+        for attempt in range(1, retries + 1):
+            try:
+                await self._project.refresh()
+                project_id = getattr(self._project, "project_id", "aristotle")
+                tar_path = dest / f"{project_id}.tar.gz"
+                await self._project.get_files(destination=tar_path)
+                with tarfile.open(tar_path) as tar:
+                    tar.extractall(dest)  # noqa: S202 - trusted Aristotle output
+                roots = [p for p in dest.iterdir() if p.is_dir()]
+                if roots:
+                    return next((p for p in roots if p.name.endswith("_aristotle")), roots[0])
+                last_err = RuntimeError("tarball extracted no project directory")
+            except Exception as err:
+                last_err = err
+                logger.warning("download_result attempt %d/%d failed: %s", attempt, retries, err)
+            if attempt < retries:
+                await asyncio.sleep(retry_delay)
+        logger.error("download_result exhausted %d retries: %s", retries, last_err)
+        return None
+
     # ------------------------------------------------------------------
     # Protocol: complete
     # ------------------------------------------------------------------

--- a/core/inference/sdk/aristotle_test.py
+++ b/core/inference/sdk/aristotle_test.py
@@ -1,0 +1,236 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Tests for AristotleInference — job submission, polling, and steering.
+
+These use an injected fake ``aristotlelib`` (the ``lib`` constructor arg) so
+no network access or API key is required.
+"""
+
+from __future__ import annotations
+
+import types
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.inference import InferenceConfig, ToolResult, ToolSchema
+from ..sdk.aristotle import (
+    AristotleInference,
+    _CONTINUABLE_STATUSES,
+    _IN_FLIGHT_STATUSES,
+    _map_finish_reason,
+    _status_value,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeTask:
+    """A task that walks through ``statuses`` on successive ``refresh`` calls."""
+
+    def __init__(self, statuses: list[str], output_summary: str = "Proved the theorem.") -> None:
+        self._statuses = statuses
+        self._i = 0
+        self.status = statuses[0]
+        self.output_summary = output_summary
+        self.agent_task_id = "task-1"
+
+    async def refresh(self) -> None:
+        self._i = min(self._i + 1, len(self._statuses) - 1)
+        self.status = self._statuses[self._i]
+
+
+class FakeProject:
+    def __init__(self, task: FakeTask) -> None:
+        self._task = task
+        self.project_id = "proj-1"
+        self.ask_prompts: list[str] = []
+
+    async def get_tasks(self, limit: int = 1, newest_first: bool = True) -> tuple[list[FakeTask], None]:
+        return [self._task], None
+
+    async def ask(self, prompt: str) -> FakeTask:
+        self.ask_prompts.append(prompt)
+        return self._task
+
+
+def _make_lib(project: FakeProject) -> Any:
+    """Build a fake ``aristotlelib`` module exposing the surface we call."""
+    create = AsyncMock(return_value=project)
+    create_from_directory = AsyncMock(return_value=project)
+    lib = types.SimpleNamespace(
+        Project=types.SimpleNamespace(create=create, create_from_directory=create_from_directory),
+        set_api_key=lambda key: key,
+    )
+    return lib
+
+
+def _make_inference(project: FakeProject, **kwargs: Any) -> AristotleInference:
+    return AristotleInference(model_name="aristotle", poll_interval=0, lib=_make_lib(project), **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Status helpers
+# ---------------------------------------------------------------------------
+
+
+class TestStatusHelpers:
+    def test_status_value_from_enum_like(self):
+        assert _status_value(types.SimpleNamespace(value="QUEUED")) == "QUEUED"
+
+    def test_status_value_from_string(self):
+        assert _status_value("COMPLETE") == "COMPLETE"
+
+    def test_in_flight_membership(self):
+        assert "IN_PROGRESS" in _IN_FLIGHT_STATUSES
+        assert "COMPLETE" not in _IN_FLIGHT_STATUSES
+
+    def test_continuable_membership(self):
+        assert "OUT_OF_BUDGET" in _CONTINUABLE_STATUSES
+        assert "COMPLETE_WITH_ERRORS" in _CONTINUABLE_STATUSES
+        assert "FAILED" not in _CONTINUABLE_STATUSES
+
+    @pytest.mark.parametrize(
+        "status,expected",
+        [
+            ("COMPLETE", "stop"),
+            ("COMPLETE_WITH_ERRORS", "stop"),
+            ("OUT_OF_BUDGET", "length"),
+            ("FAILED", "error"),
+            ("CANCELED", "cancelled"),
+        ],
+    )
+    def test_map_finish_reason(self, status: str, expected: str):
+        assert _map_finish_reason(status) == expected
+
+
+# ---------------------------------------------------------------------------
+# Conversation management
+# ---------------------------------------------------------------------------
+
+
+class TestConversationManagement:
+    def test_system_prompt_roundtrip(self):
+        inf = _make_inference(FakeProject(FakeTask(["COMPLETE"])))
+        inf.set_system_prompt("You are a Lean expert.")
+        assert inf.get_system_prompt() == "You are a Lean expert."
+
+    def test_get_messages_includes_system(self):
+        inf = _make_inference(FakeProject(FakeTask(["COMPLETE"])))
+        inf.set_system_prompt("sys")
+        inf.add_user_message("hi")
+        msgs = inf.get_messages()
+        assert msgs[0] == {"role": "system", "content": "sys"}
+        assert msgs[1] == {"role": "user", "content": "hi"}
+
+    def test_tool_results_folded_into_user_message(self):
+        inf = _make_inference(FakeProject(FakeTask(["COMPLETE"])))
+        inf.add_tool_results([ToolResult(tool_call_id="x", content="ok"), ToolResult(tool_call_id="y", content="boom", is_error=True)])
+        contents = [m["content"] for m in inf.get_messages()]
+        assert "[tool result] ok" in contents
+        assert "[tool error] boom" in contents
+
+    def test_cleanup_interrupted_strips_empty_assistant(self):
+        inf = _make_inference(FakeProject(FakeTask(["COMPLETE"])))
+        inf.add_user_message("hi")
+        inf._messages.append({"role": "assistant", "content": "  "})
+        inf.cleanup_interrupted()
+        assert inf._messages[-1] == {"role": "user", "content": "hi"}
+
+    @pytest.mark.asyncio
+    async def test_reset_drops_project(self):
+        project = FakeProject(FakeTask(["COMPLETE"]))
+        inf = _make_inference(project)
+        inf.add_user_message("prove x")
+        await inf.complete()
+        assert inf._project is not None
+        inf.reset()
+        assert inf._project is None
+        assert inf._messages == []
+
+
+# ---------------------------------------------------------------------------
+# complete()
+# ---------------------------------------------------------------------------
+
+
+class TestComplete:
+    @pytest.mark.asyncio
+    async def test_first_turn_creates_project_and_returns_summary(self):
+        project = FakeProject(FakeTask(["QUEUED", "IN_PROGRESS", "COMPLETE"], output_summary="QED"))
+        inf = _make_inference(project)
+        inf.add_user_message("prove 1+1=2")
+        result = await inf.complete()
+
+        assert result.text == "QED"
+        assert result.finish_reason == "stop"
+        assert result.tool_calls == []
+        assert result.usage.total_tokens == 0
+        assert result.call_id == "task-1"
+        inf._lib.Project.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_first_turn_with_project_dir_bundles_directory(self, tmp_path):
+        project = FakeProject(FakeTask(["COMPLETE"]))
+        inf = _make_inference(project, project_dir=tmp_path)
+        inf.add_user_message("fill the sorries")
+        await inf.complete()
+        inf._lib.Project.create_from_directory.assert_awaited_once()
+        inf._lib.Project.create.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_second_turn_continues_via_ask(self):
+        project = FakeProject(FakeTask(["COMPLETE"]))
+        inf = _make_inference(project)
+        inf.add_user_message("prove lemma A")
+        await inf.complete()
+        inf.add_user_message("now prove lemma B")
+        await inf.complete()
+        assert project.ask_prompts == ["now prove lemma B"]
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_prepended_on_first_submission(self):
+        project = FakeProject(FakeTask(["COMPLETE"]))
+        inf = _make_inference(project)
+        inf.set_system_prompt("Use Mathlib conventions.")
+        inf.add_user_message("prove it")
+        await inf.complete()
+        _, kwargs = inf._lib.Project.create.call_args
+        assert "Use Mathlib conventions." in kwargs["prompt"]
+        assert "prove it" in kwargs["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_tools_are_ignored(self):
+        project = FakeProject(FakeTask(["COMPLETE"]))
+        inf = _make_inference(project)
+        inf.add_user_message("prove it")
+        result = await inf.complete(
+            tools=[ToolSchema(name="read", description="d", parameters={})],
+            inference_config=InferenceConfig(),
+        )
+        assert result.tool_calls == []
+
+    @pytest.mark.asyncio
+    async def test_out_of_budget_maps_to_length(self):
+        project = FakeProject(FakeTask(["OUT_OF_BUDGET"], output_summary="partial"))
+        inf = _make_inference(project)
+        inf.add_user_message("prove it")
+        result = await inf.complete()
+        assert result.finish_reason == "length"
+        assert inf._last_status == "OUT_OF_BUDGET"
+
+    @pytest.mark.asyncio
+    async def test_empty_summary_falls_back_to_placeholder(self):
+        project = FakeProject(FakeTask(["COMPLETE"], output_summary=""))
+        inf = _make_inference(project)
+        inf.add_user_message("prove it")
+        result = await inf.complete()
+        assert "no summary" in result.text

--- a/core/inference/sdk/aristotle_test.py
+++ b/core/inference/sdk/aristotle_test.py
@@ -316,6 +316,26 @@ class TestSteering:
         assert inf._steer_count == 0
 
     @pytest.mark.asyncio
+    async def test_steer_ask_failure_does_not_crash_run(self):
+        events = [FakeEvent("e1", "EDITING_FILE")]
+        running = FakeTask(["IN_PROGRESS", "IN_PROGRESS", "COMPLETE"], events=events)
+        project = FakeProject(running)
+
+        async def boom(prompt: str):
+            raise RuntimeError("429 too many requests")
+
+        project.ask = boom  # type: ignore[method-assign]
+
+        async def steer(new_events, task):
+            return "redirect"
+
+        inf = _make_inference(project, steer=steer)
+        inf.add_user_message("prove it")
+        result = await inf.complete()  # must not raise
+        assert result.finish_reason == "stop"
+        assert inf._steer_count == 0
+
+    @pytest.mark.asyncio
     async def test_no_duplicate_events_across_polls(self):
         events = [FakeEvent("e1", "THINKING")]
         # Stays in flight several polls; the same event must be delivered once.

--- a/core/inference/sdk/aristotle_test.py
+++ b/core/inference/sdk/aristotle_test.py
@@ -33,24 +33,46 @@ from ..sdk.aristotle import (
 # ---------------------------------------------------------------------------
 
 
-class FakeTask:
-    """A task that walks through ``statuses`` on successive ``refresh`` calls."""
+class FakeEvent:
+    def __init__(self, event_id: str, event_type_name: str) -> None:
+        self.event_id = event_id
+        self.event_type = types.SimpleNamespace(name=event_type_name)
 
-    def __init__(self, statuses: list[str], output_summary: str = "Proved the theorem.") -> None:
+
+class FakeTask:
+    """A task that walks through ``statuses`` on successive ``refresh`` calls.
+
+    Optionally surfaces ``events`` (newest-first) so the event-watcher /
+    steering path can be exercised.
+    """
+
+    def __init__(
+        self,
+        statuses: list[str],
+        output_summary: str = "Proved the theorem.",
+        events: list[FakeEvent] | None = None,
+        agent_task_id: str = "task-1",
+    ) -> None:
         self._statuses = statuses
         self._i = 0
         self.status = statuses[0]
         self.output_summary = output_summary
-        self.agent_task_id = "task-1"
+        self.agent_task_id = agent_task_id
+        self._events = events or []
 
     async def refresh(self) -> None:
         self._i = min(self._i + 1, len(self._statuses) - 1)
         self.status = self._statuses[self._i]
 
+    async def get_events(self, limit: int = 50, newest_first: bool = True) -> tuple[list[FakeEvent], None]:
+        evs = list(reversed(self._events)) if newest_first else list(self._events)
+        return evs[:limit], None
+
 
 class FakeProject:
-    def __init__(self, task: FakeTask) -> None:
+    def __init__(self, task: FakeTask, ask_returns: FakeTask | None = None) -> None:
         self._task = task
+        self._ask_returns = ask_returns
         self.project_id = "proj-1"
         self.ask_prompts: list[str] = []
 
@@ -59,7 +81,7 @@ class FakeProject:
 
     async def ask(self, prompt: str) -> FakeTask:
         self.ask_prompts.append(prompt)
-        return self._task
+        return self._ask_returns if self._ask_returns is not None else self._task
 
 
 def _make_lib(project: FakeProject) -> Any:
@@ -234,3 +256,76 @@ class TestComplete:
         inf.add_user_message("prove it")
         result = await inf.complete()
         assert "no summary" in result.text
+
+
+# ---------------------------------------------------------------------------
+# In-flight observation + steering
+# ---------------------------------------------------------------------------
+
+
+class TestSteering:
+    @pytest.mark.asyncio
+    async def test_on_event_observer_receives_events(self):
+        events = [FakeEvent("e1", "THINKING"), FakeEvent("e2", "EDITING_FILE")]
+        project = FakeProject(FakeTask(["IN_PROGRESS", "COMPLETE"], events=events))
+        seen: list[str] = []
+
+        async def observer(ev):
+            seen.append(ev.event_type.name)
+
+        inf = _make_inference(project, on_event=observer)
+        inf.add_user_message("prove it")
+        await inf.complete()
+        assert seen == ["THINKING", "EDITING_FILE"]
+        assert project.ask_prompts == []  # observation only, no steering
+
+    @pytest.mark.asyncio
+    async def test_steer_injects_ask_while_in_flight(self):
+        events = [FakeEvent("e1", "EDITING_FILE")]
+        running = FakeTask(["IN_PROGRESS", "IN_PROGRESS", "IN_PROGRESS"], events=events)
+        steered = FakeTask(["COMPLETE"], output_summary="fixed", agent_task_id="task-2")
+        project = FakeProject(running, ask_returns=steered)
+
+        async def steer(new_events, task):
+            if any(e.event_type.name == "EDITING_FILE" for e in new_events):
+                return "you are off-course; use `norm_num`"
+            return None
+
+        inf = _make_inference(project, steer=steer)
+        inf.add_user_message("prove it")
+        result = await inf.complete()
+
+        assert project.ask_prompts == ["you are off-course; use `norm_num`"]
+        assert inf._steer_count == 1
+        # Polling followed the live session onto the steered task.
+        assert result.text == "fixed"
+        assert result.call_id == "task-2"
+
+    @pytest.mark.asyncio
+    async def test_steer_returning_none_does_not_ask(self):
+        events = [FakeEvent("e1", "THINKING")]
+        project = FakeProject(FakeTask(["IN_PROGRESS", "COMPLETE"], events=events))
+
+        async def steer(new_events, task):
+            return None
+
+        inf = _make_inference(project, steer=steer)
+        inf.add_user_message("prove it")
+        await inf.complete()
+        assert project.ask_prompts == []
+        assert inf._steer_count == 0
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_events_across_polls(self):
+        events = [FakeEvent("e1", "THINKING")]
+        # Stays in flight several polls; the same event must be delivered once.
+        project = FakeProject(FakeTask(["IN_PROGRESS", "IN_PROGRESS", "IN_PROGRESS", "COMPLETE"], events=events))
+        count = {"n": 0}
+
+        async def observer(ev):
+            count["n"] += 1
+
+        inf = _make_inference(project, on_event=observer)
+        inf.add_user_message("prove it")
+        await inf.complete()
+        assert count["n"] == 1

--- a/docs/pipeline/aristotle_worker.md
+++ b/docs/pipeline/aristotle_worker.md
@@ -1,0 +1,85 @@
+# Aristotle worker (Mode-B integration)
+
+Harmonic's **Aristotle** is an autonomous formal-reasoning agent: give it a Lean
+project + a goal and it runs its *own* internal tools (proof search, Lean
+builds, file edits) and returns finished files. That doesn't fit AutoformBot's
+default worker, which is a turn-based, tool-calling LLM agent driven move by
+move. This note describes how Aristotle is integrated **as a worker** instead.
+
+## Two modes (and why this is Mode B)
+
+- **Mode A — Aristotle as a served model.** `core/inference/sdk/aristotle.py`
+  registers `Aristotle` in the model registry, so `model: "Aristotle"` resolves
+  and `create_inference` builds the backend. This is enough for the simple
+  `InferenceProtocol` consumers (statement extraction, the LLM graders) but
+  **not** for the worker loop: that loop hands the agent MCP tools and expects
+  `tool_calls` back plus incremental worktree edits — Aristotle returns prose +
+  a finished tarball, so a worker "powered by Aristotle" would edit nothing in
+  its worktree. *Selectable ≠ operational.*
+
+- **Mode B — Aristotle as a worker (this).** In `ConcurrentAgents.run_task`, the
+  **only** model-specific step is `agent.call(task.description)` — everything
+  after it (`rebase` → `build` → `review` → `_attempt_merge`) operates on the
+  agent's git worktree and is model-agnostic. So we swap just that step.
+
+## The seam: `AristotleAgent`
+
+`autoform/bot/aristotle_agent.py` defines `AristotleAgent`, which **duck-types
+the `core.agent.Agent` surface** that `run_task` uses (`id`, `worktree_path`,
+async `call`, `reset`, `set_trace`, `total_turns`, `messages`). Its `call()`:
+
+1. bundles the **whole worktree** as Aristotle's project context
+   (`AristotleInference(project_dir=worktree)`),
+2. submits the task description, polls to a terminal status (optionally
+   observing/steering via the `on_event`/`steer` hooks),
+3. **lands** the returned files over the worktree and **commits** them
+   (authored by Aristotle, co-author trailer).
+
+Then `run_task` proceeds exactly as for an LLM worker: rebase, build, review,
+merge. Nothing else in the pipeline changes — the merge queue, worktree
+isolation, racing, and the supervisor's eval harness all act on files/compiled
+output and are author-agnostic.
+
+```
+            run_task (UNCHANGED)
+   agent.call ─► rebase ─► build ─► review ─► merge ─► main
+       │
+   AristotleAgent.call:  bundle worktree → Aristotle → land files → commit
+```
+
+## What's implemented
+
+- `AristotleAgent` + `create_aristotle_agents` (`autoform/bot/aristotle_agent.py`)
+- `solver` config field (`llm.solver: agent | aristotle`) in `autoform/bot/config.py`
+- Unit + integration tests (`autoform/bot/aristotle_agent_test.py`) — including
+  driving a real `ConcurrentAgents.run_task` to a merge with a fake backend.
+- A runnable worker-tier demo (`examples/aristotle_worker_demo.py`) that takes a
+  *real* Aristotle submission all the way to `main`.
+
+## What remains to fully activate `solver: aristotle`
+
+The demo constructs the agent directly. To flip the whole pipeline over, the
+node still needs to build Aristotle agents instead of LLM agents:
+
+- In `autoform/bot/worker_node.py` / `pool.py`, branch on `config.solver`: when
+  `aristotle`, create a pool of `AristotleAgent`s over the per-agent worktrees
+  (reusing worktree creation; skipping the REPL/LSP/MCP setup Aristotle doesn't
+  use). Reviewers can remain LLM agents, or the `steer` hook can play the
+  reviewer role in-flight (Hermes-style).
+- Thread `solver` from `main.py` into `LeanWorkerNode`.
+
+These are mechanical wiring changes; the design above is the substantive part.
+
+## Caveats
+
+- **Granularity & cost.** Aristotle jobs run minutes–hours; racing several per
+  target is expensive. Use `min_agents_per_task: 1` and a separate concurrency
+  budget — don't reuse the LLM-call resource pool sizing.
+- **Build is the real gate.** With `LeanConcurrentAgents`, `build()` runs
+  `lake build`; a returned project with `sorry`/errors fails the build (and the
+  supervisor's harness rejects unjustified `sorry`/axioms), so Aristotle's
+  output is held to the same bar as any worker's.
+- **Orchestrator/supervisor unchanged.** The DAG planner and eval harness are
+  upstream/downstream of the worker and don't change. (One real subtlety for
+  copyrighted sources: the orchestrator and reviewers also read source text, so
+  a fully copyright-confined run would need those to be Aristotle-only too.)

--- a/docs/pipeline/aristotle_worker.md
+++ b/docs/pipeline/aristotle_worker.md
@@ -49,26 +49,43 @@ output and are author-agnostic.
 
 ## What's implemented
 
-- `AristotleAgent` + `create_aristotle_agents` (`autoform/bot/aristotle_agent.py`)
-- `solver` config field (`llm.solver: agent | aristotle`) in `autoform/bot/config.py`
-- Unit + integration tests (`autoform/bot/aristotle_agent_test.py`) — including
-  driving a real `ConcurrentAgents.run_task` to a merge with a fake backend.
+- `AristotleAgent` + `create_aristotle_agents` + `create_aristotle_pool`
+  (`autoform/bot/aristotle_agent.py`).
+- `solver` config field (`llm.solver: agent | aristotle`) in `autoform/bot/config.py`.
+- **Full pipeline wiring:** `LeanWorkerNode.initialize()` branches on `solver` —
+  when `aristotle`, it builds an Aristotle worker pool (`create_aristotle_pool`:
+  same worktrees + `.lake` symlink, no REPL/LSP, no reviewers) instead of the
+  LLM pool. `main.py` threads `solver` from the config. The `LeanConcurrentAgents`
+  build gate (`lake build`) and merge queue are reused unchanged.
+- Unit + integration tests (`autoform/bot/aristotle_agent_test.py`): land/commit,
+  pool construction (real worktrees + `AgentPool` lifecycle), and driving a real
+  `ConcurrentAgents.run_task` to a merge with a fake backend.
 - A runnable worker-tier demo (`examples/aristotle_worker_demo.py`) that takes a
   *real* Aristotle submission all the way to `main`.
 
-## What remains to fully activate `solver: aristotle`
+## Running it
 
-The demo constructs the agent directly. To flip the whole pipeline over, the
-node still needs to build Aristotle agents instead of LLM agents:
+```yaml
+# config.yaml
+llm:
+  solver: aristotle      # workers are Aristotle; model only matters if reviewers are enabled
+workers:
+  agents_per_node: 1     # Aristotle jobs are slow/expensive — don't race many
+  min_agents_per_task: 1
+  max_agents_per_task: 1
+```
 
-- In `autoform/bot/worker_node.py` / `pool.py`, branch on `config.solver`: when
-  `aristotle`, create a pool of `AristotleAgent`s over the per-agent worktrees
-  (reusing worktree creation; skipping the REPL/LSP/MCP setup Aristotle doesn't
-  use). Reviewers can remain LLM agents, or the `steer` hook can play the
-  reviewer role in-flight (Hermes-style).
-- Thread `solver` from `main.py` into `LeanWorkerNode`.
+`ARISTOTLE_API_KEY` must be in the environment (the SDK reads it directly).
+Everything else — orchestrator DAG planning, the supervisor's eval harness,
+the merge queue — is unchanged.
 
-These are mechanical wiring changes; the design above is the substantive part.
+## Not yet done (deliberately)
+
+- **Reviewers.** Mode-B workers currently have no paired reviewer; the build
+  gate + supervisor eval still apply. A natural next step is to let the `steer`
+  hook play an in-flight reviewer (Hermes-style) rather than a post-hoc one.
+- **Separate concurrency budget.** Aristotle jobs are long; the LLM-call
+  resource-pool sizing isn't the right knob for them.
 
 ## Caveats
 

--- a/docs/pipeline/bot.md
+++ b/docs/pipeline/bot.md
@@ -224,6 +224,7 @@ workers:
 
 llm:
   model: "Opus 4.6"           # Model name resolved via core.inference.client.lookup_model
+                              # "Aristotle" routes to Harmonic's agent (see note below)
 
 book:
   path: books/my_textbook     # Path to book data under autoform/data/

--- a/examples/aristotle_worker_demo.py
+++ b/examples/aristotle_worker_demo.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""End-to-end demo of the Mode-B Aristotle worker (the worker tier of the pipeline).
+
+Drives a *real* Aristotle submission through the unmodified
+``ConcurrentAgents.run_task`` loop:
+
+    create throwaway repo + worktree
+      -> AristotleAgent.call(): bundle worktree to Aristotle, land + commit files
+      -> rebase -> build -> review(none) -> merge to main
+
+`build()` here is the base no-op (so the demo needs no Mathlib checkout); the
+production pipeline uses ``LeanConcurrentAgents.build`` = `lake build`. This
+demo proves the *integration mechanism*: Aristotle's output flows through the
+real worker-tier machinery onto `main`.
+
+Run:  ARISTOTLE_API_KEY=arstl_... python -m examples.aristotle_worker_demo
+"""
+
+import asyncio
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import aristotlelib
+
+from autoform.bot.aristotle_agent import AristotleAgent
+from core import worktree
+from core.coordination.concurrent_agents import ConcurrentAgents
+from core.task import Task
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("demo")
+
+
+def _git(args, cwd):
+    return subprocess.run(["git", "-c", "user.name=demo", "-c", "user.email=demo@demo", *args],
+                          cwd=cwd, capture_output=True, text=True)
+
+
+def _seed_repo(root: Path) -> None:
+    """A minimal Lean v4.28 project committed on main."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "lean-toolchain").write_text("leanprover/lean4:v4.28.0\n")
+    (root / "lakefile.toml").write_text(
+        'name = "Demo"\ndefaultTargets = ["Demo"]\n\n'
+        '[[require]]\nname = "mathlib"\n'
+        'git = "https://github.com/leanprover-community/mathlib4.git"\nrev = "v4.28.0"\n\n'
+        '[[lean_lib]]\nname = "Demo"\n'
+    )
+    (root / "Demo").mkdir(exist_ok=True)
+    (root / "Demo" / "Target.lean").write_text(
+        "import Mathlib\n\n-- TODO(aristotle): prove `1 + 1 = 2`\n"
+    )
+    _git(["init", "-b", "main"], root)
+    _git(["add", "-A"], root)
+    _git(["commit", "-m", "seed Demo project"], root)
+
+
+async def main() -> int:
+    key = os.environ.get("ARISTOTLE_API_KEY")
+    if not key:
+        print("Set ARISTOTLE_API_KEY", file=sys.stderr)
+        return 2
+    aristotlelib.set_api_key(key)
+
+    tmp = Path(tempfile.mkdtemp(prefix="aristotle-worker-demo-"))
+    repo = tmp / "repo"
+    _seed_repo(repo)
+    wt = worktree.create_worktree(repo, "worker0", worktrees_dir=tmp / "worktrees")
+    log.info("repo=%s worktree=%s", repo, wt)
+
+    async def on_event(ev):
+        et = getattr(getattr(ev, "event_type", None), "name", "?")
+        log.info("  [aristotle] %s", et)
+
+    agent = AristotleAgent(id="aristotle-worker-0", worktree_path=wt, on_event=on_event,
+                           poll_interval=15, max_wait_seconds=1800)
+
+    task = Task(
+        id="demo-1",
+        title="prove 1+1=2",
+        description="In `Demo/Target.lean`, replace the TODO with a complete Lean 4 proof "
+                    "that `1 + 1 = 2` (using Mathlib). The project must build.",
+    )
+
+    ca = ConcurrentAgents(repo_root=repo)  # base: build() is a no-op (no Mathlib needed)
+    log.info("running worker-tier loop (this submits to Aristotle)...")
+    result = await ca.run_task(task, [agent], get_reviewer=None)
+
+    log.info("\n=== result: success=%s winner=%s ===", result.success, result.winner_id)
+    if result.success:
+        log.info("Demo/Target.lean on main:\n%s", _git(["show", "main:Demo/Target.lean"], repo).stdout)
+        log.info("commit: %s", _git(["log", "-1", "--format=%h %an: %s"], repo).stdout.strip())
+    else:
+        log.info("error: %s", result.error)
+    log.info("(artifacts under %s)", tmp)
+    return 0 if result.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+aristotle = [
+    "aristotlelib>=2.0",
+]
 webapp = [
     "fastapi>=0.100",
     "flask>=3.0",


### PR DESCRIPTION
Human note: This PR is still under development and testing. Please do not waste time reviewing it in it's current state. Everything below is AI-generated.

## Summary

Adds an optional **`Aristotle`** model that routes to [Harmonic's Aristotle](https://aristotle.harmonic.fun) autonomous formal-reasoning agent, alongside the existing Anthropic / OpenAI / Gemini / local backends. It depends only on the public `aristotlelib` SDK (no proprietary or third-party-repo dependencies) and is gated behind an optional `aristotle` extra.

## Why this is a little different from the other backends

Aristotle is **not** a turn-based chat model. It takes a prompt (optionally bundling a whole Lean project), runs its *own* internal tools (proof search, Lean builds, file edits), and returns finished files plus a natural-language summary. `AristotleInference` maps that job-based API onto `InferenceProtocol`:

- One persistent `Project` backs each conversation, created lazily on the first `complete()` (optionally bundling a seed Lean project via `Project.create_from_directory`).
- Each turn submits the latest user message — first turn via `Project.create[_from_directory]`, later turns via `project.ask` (which reuses Aristotle's live server-side session) — then polls the resulting `AgentTask` to a terminal `TaskStatus`.
- The task's `output_summary` becomes the assistant text; result files can optionally be downloaded/extracted via `download_dir`.

## In-flight steering

While a task runs you can redirect it: issue `project.ask(...)` on the live session. The backend exposes this through two optional callbacks:

- `on_event(event)` — async observer called per new event as the task runs (progress, logging).
- `steer(new_events, task)` — async callback invoked with each batch of new events; return a non-empty prompt to inject via `project.ask` while the task is still in flight, and polling follows the resulting task. This is the upstreamable generalization of a live-steering watcher (observe the event stream → judge → redirect).

Between-turn steering via follow-up `complete()` calls also works (each reuses the live session).

## Documented limitations

- **No per-turn tool calling** — Aristotle runs its own tools, so `tools` are ignored and `tool_calls` is always empty.
- **No token-usage / prompt caching** — Aristotle bills by compute, so `TokenUsage` is zero and `CacheConfig` is a no-op.

## Changes

- `core/inference/sdk/aristotle.py` — `AristotleInference` backend (incl. `on_event` / `steer` in-flight hooks)
- `core/inference/client.py` — `Backend.ARISTOTLE` + `Aristotle` model entry
- `pyproject.toml` — optional `aristotle` extra (`aristotlelib>=2.0`)
- `README.md`, `docs/pipeline/bot.md` — setup (`ARISTOTLE_API_KEY`) and caveats
- `core/inference/sdk/aristotle_test.py` — unit tests using an injected fake SDK (no network/key)

## Testing

**Unit tests** — `pytest core/inference/sdk/aristotle_test.py`: 25 passing (status classification, conversation management, first-turn create, project-dir bundling, continuation-via-ask, system-prompt prepend, tools-ignored, out-of-budget mapping, empty-summary fallback, event observation, in-flight steering injection, steer-returns-None, event de-duplication). `ruff check` clean on all changed files. The `aristotlelib` import is lazy, so the inference package imports fine without the optional dependency installed.

**Live end-to-end run** — verified against the real Aristotle API (`api/v3`) with a valid `ARISTOTLE_API_KEY`. Two runs: (1) `"Prove in Lean 4 that 1 + 1 = 2"` → `finish_reason="stop"` with a compiling `by norm_num` proof; (2) a real chapter-bundled formalization task via `project_dir` (`create_from_directory`) → completed and downloaded/extracted a sorry-free Lean file. Full path exercised: `set_api_key` → `Project.create[_from_directory]` → poll `AgentTask` → map `output_summary` into `TurnResult`.

Usage: set `model: "Aristotle"` in the bot config (or pass `"Aristotle"` to `lookup_model`) with `ARISTOTLE_API_KEY` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)